### PR TITLE
Add training and sales modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## Additional Modules
+
+This project now includes simple examples of a training module for employees and
+a sales & billing page for administrators.

--- a/src/app/actions/admin/invoicing/createInvoice.ts
+++ b/src/app/actions/admin/invoicing/createInvoice.ts
@@ -1,0 +1,45 @@
+'use server';
+
+import { z } from 'zod';
+import { db } from '@/lib/firebase';
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+
+const CreateInvoiceSchema = z.object({
+  clientName: z.string().min(1, { message: 'Client name is required.' }),
+  projectId: z.string().min(1, { message: 'Project ID is required.' }),
+  amount: z.number().positive({ message: 'Amount must be greater than 0.' }),
+  dueDate: z.string(), // yyyy-MM-dd
+});
+
+export type CreateInvoiceInput = z.infer<typeof CreateInvoiceSchema>;
+
+export interface CreateInvoiceResult {
+  success: boolean;
+  message: string;
+  invoiceId?: string;
+  errors?: z.ZodIssue[];
+}
+
+export async function createInvoice(adminId: string, input: CreateInvoiceInput): Promise<CreateInvoiceResult> {
+  if (!adminId) {
+    return { success: false, message: 'Admin ID not provided.' };
+  }
+
+  const validation = CreateInvoiceSchema.safeParse(input);
+  if (!validation.success) {
+    return { success: false, message: 'Invalid input.', errors: validation.error.issues };
+  }
+
+  try {
+    const docRef = await addDoc(collection(db, 'invoices'), {
+      ...validation.data,
+      createdBy: adminId,
+      createdAt: serverTimestamp(),
+    });
+    return { success: true, message: 'Invoice created.', invoiceId: docRef.id };
+  } catch (error) {
+    console.error('Error creating invoice:', error);
+    const msg = error instanceof Error ? error.message : 'An unexpected error occurred.';
+    return { success: false, message: `Failed to create invoice: ${msg}` };
+  }
+}

--- a/src/app/actions/training/getTrainingMaterials.ts
+++ b/src/app/actions/training/getTrainingMaterials.ts
@@ -1,0 +1,29 @@
+'use server';
+
+export interface TrainingMaterial {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  mediaUrl: string;
+}
+
+export async function getTrainingMaterials(): Promise<TrainingMaterial[]> {
+  // Placeholder implementation; in a real app this would fetch from Firestore
+  return [
+    {
+      id: '1',
+      title: 'Safety Basics',
+      description: 'Mandatory safety training for new employees.',
+      category: 'safety',
+      mediaUrl: '/training/safety-basics.mp4'
+    },
+    {
+      id: '2',
+      title: 'Equipment Usage',
+      description: 'Guide to operating standard equipment.',
+      category: 'equipment',
+      mediaUrl: '/training/equipment-usage.pdf'
+    }
+  ];
+}

--- a/src/app/dashboard/admin/sales-billing/page.tsx
+++ b/src/app/dashboard/admin/sales-billing/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from 'react';
+import { PageHeader } from "@/components/shared/page-header";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import { CalendarIcon, PlusCircle } from "lucide-react";
+import { format } from 'date-fns';
+import { useAuth } from '@/context/auth-context';
+import { useToast } from '@/hooks/use-toast';
+import { createInvoice, type CreateInvoiceInput } from '@/app/actions/admin/invoicing/createInvoice';
+
+export default function SalesBillingPage() {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [formData, setFormData] = useState<CreateInvoiceInput>({
+    clientName: '',
+    projectId: '',
+    amount: 0,
+    dueDate: format(new Date(), 'yyyy-MM-dd')
+  });
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!user?.id) return;
+    setSubmitting(true);
+    const result = await createInvoice(user.id, formData);
+    if (result.success) {
+      toast({ title: 'Invoice Created', description: `Invoice ID: ${result.invoiceId}` });
+      setFormData({ clientName: '', projectId: '', amount: 0, dueDate: format(new Date(), 'yyyy-MM-dd') });
+    } else {
+      toast({ title: 'Creation Failed', description: result.message, variant: 'destructive' });
+    }
+    setSubmitting(false);
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Sales & Billing" description="Create and manage client invoices." />
+      <Card>
+        <CardHeader>
+          <CardTitle className="font-headline text-xl">Create Invoice</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <Label htmlFor="clientName">Client Name</Label>
+              <Input id="clientName" value={formData.clientName} onChange={e => setFormData({ ...formData, clientName: e.target.value })} />
+            </div>
+            <div>
+              <Label htmlFor="projectId">Project ID</Label>
+              <Input id="projectId" value={formData.projectId} onChange={e => setFormData({ ...formData, projectId: e.target.value })} />
+            </div>
+            <div>
+              <Label htmlFor="amount">Amount</Label>
+              <Input type="number" id="amount" value={formData.amount} onChange={e => setFormData({ ...formData, amount: parseFloat(e.target.value) })} />
+            </div>
+            <div className="flex flex-col">
+              <Label>Due Date</Label>
+              <Popover open={showDatePicker} onOpenChange={setShowDatePicker}>
+                <PopoverTrigger asChild>
+                  <Button variant="outline" type="button" className="justify-start">
+                    <CalendarIcon className="mr-2 h-4 w-4" />
+                    {format(new Date(formData.dueDate), 'PPP')}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent>
+                  <Calendar
+                    mode="single"
+                    selected={new Date(formData.dueDate)}
+                    onSelect={(date) => {
+                      if (date) setFormData({ ...formData, dueDate: format(date, 'yyyy-MM-dd') });
+                      setShowDatePicker(false);
+                    }}
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+            <Button type="submit" disabled={submitting} className="bg-accent hover:bg-accent/90">
+              {submitting ? 'Creating...' : (<><PlusCircle className="mr-2 h-4 w-4" /> Create Invoice</>)}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/dashboard/employee/training/page.tsx
+++ b/src/app/dashboard/employee/training/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { PageHeader } from "@/components/shared/page-header";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { TrainingMaterial } from '@/app/actions/training/getTrainingMaterials';
+import { getTrainingMaterials } from '@/app/actions/training/getTrainingMaterials';
+
+export default function TrainingPage() {
+  const [materials, setMaterials] = useState<TrainingMaterial[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const data = await getTrainingMaterials();
+      setMaterials(data);
+    }
+    load();
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Training Materials" description="Access task-specific training materials." />
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {materials.map((mat) => (
+          <Card key={mat.id}>
+            <CardHeader>
+              <CardTitle className="font-headline text-xl">{mat.title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground mb-2">{mat.description}</p>
+              <p className="text-xs text-muted-foreground">Category: {mat.category}</p>
+            </CardContent>
+          </Card>
+        ))}
+        {materials.length === 0 && (
+          <Card>
+            <CardContent className="p-6 text-center text-muted-foreground">
+              No training materials found.
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/app-sidebar-nav.tsx
+++ b/src/components/layout/app-sidebar-nav.tsx
@@ -3,7 +3,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Briefcase, ListChecks, Users, UserCog, LayoutDashboard, CheckCircle, AlertTriangle, Settings, BarChart3, FilePlus, ClipboardList, LibraryBig, PackagePlus, DollarSign, ReceiptText, Archive, CreditCard, Files, TestTube2, WalletCards } from "lucide-react";
+import { Briefcase, ListChecks, Users, UserCog, LayoutDashboard, CheckCircle, AlertTriangle, Settings, BarChart3, FilePlus, ClipboardList, LibraryBig, PackagePlus, DollarSign, ReceiptText, Archive, CreditCard, Files, TestTube2, WalletCards, Receipt, GraduationCap } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { UserRole } from "@/types/database";
 
@@ -22,6 +22,7 @@ const baseNavItems: NavItem[] = [
   { href: "/dashboard/employee/projects", label: "My Projects", icon: Briefcase, roles: ["employee"], group: "Employee" },
   { href: "/dashboard/employee/expenses/log-expense", label: "Log Expense", icon: DollarSign, roles: ["employee"], group: "Employee" },
   { href: "/dashboard/employee/expenses/my-expenses", label: "My Expenses", icon: ReceiptText, roles: ["employee"], group: "Employee" },
+  { href: "/dashboard/employee/training", label: "Training", icon: GraduationCap, roles: ["employee"], group: "Employee" },
   
   // Supervisor
   { href: "/dashboard/supervisor/overview", label: "Team Overview", icon: Users, roles: ["supervisor"], group: "Supervisor" },
@@ -38,6 +39,7 @@ const baseNavItems: NavItem[] = [
   { href: "/dashboard/admin/overview", label: "Admin Overview", icon: LayoutDashboard, roles: ["admin"], group: "Admin"},
   { href: "/dashboard/admin/user-management", label: "User Management", icon: UserCog, roles: ["admin"], group: "Admin" },
   { href: "/dashboard/admin/project-management", label: "Project Management", icon: LibraryBig, roles: ["admin"], group: "Admin" },
+  { href: "/dashboard/admin/sales-billing", label: "Sales & Billing", icon: Receipt, roles: ["admin"], group: "Admin" },
   { href: "/dashboard/admin/payroll", label: "Payroll Dashboard", icon: WalletCards, roles: ["admin"], group: "Admin" },
   { href: "/dashboard/admin/payroll-test-panel", label: "Payroll Test Panel", icon: TestTube2, roles: ["admin"], group: "Admin" },
   { href: "/dashboard/admin/system-settings", label: "System Settings", icon: Settings, roles: ["admin"], group: "Admin" },


### PR DESCRIPTION
## Summary
- add example training page for employees
- add sales & billing page for admins
- create server actions for invoices and training materials
- update sidebar nav links
- document modules in README

## Testing
- `npx next lint` *(fails: 403 Forbidden)*
- `npm run typecheck` *(fails: Cannot find modules)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843300517b0832094ee9502848d451b