### PR TITLE
Fix type error in use-toast hook

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -158,7 +158,7 @@ function toast({ ...props }: Toast) {
       ...props,
       id,
       open: true,
-      onOpenChange: (open) => {
+      onOpenChange: (open: boolean) => {
         if (!open) dismiss()
       },
     },


### PR DESCRIPTION
## Summary
- add boolean type annotation to the open change handler in `use-toast`

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react' et al)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842afa3904c83208f20355607368b04