### PR TITLE
Add offline action queue

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster";
 import { AuthProvider } from '@/context/auth-context';
+import { OfflineQueueProvider } from '@/context/offline-queue';
+import { OfflineBanner } from '@/components/layout/offline-banner';
 
 export const metadata: Metadata = {
   title: 'FieldOps MVP',
@@ -21,9 +23,12 @@ export default function RootLayout({
         <link href="https://fonts.googleapis.com/css2?family=PT+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
       </head>
       <body className="font-body antialiased min-h-screen flex flex-col">
-        <AuthProvider>
-          {children}
-        </AuthProvider>
+        <OfflineQueueProvider>
+          <AuthProvider>
+            {children}
+          </AuthProvider>
+          <OfflineBanner />
+        </OfflineQueueProvider>
         <Toaster />
       </body>
     </html>

--- a/src/components/layout/offline-banner.tsx
+++ b/src/components/layout/offline-banner.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useOfflineQueue } from '@/context/offline-queue';
+import { useEffect, useState } from 'react';
+import { AlertCircle, CheckCircle2 } from 'lucide-react';
+
+export function OfflineBanner() {
+  const { pendingActions } = useOfflineQueue();
+  const [online, setOnline] = useState<typeof navigator extends undefined ? boolean : boolean>(typeof navigator === 'undefined' ? true : navigator.onLine);
+
+  useEffect(() => {
+    const onChange = () => setOnline(navigator.onLine);
+    window.addEventListener('online', onChange);
+    window.addEventListener('offline', onChange);
+    return () => {
+      window.removeEventListener('online', onChange);
+      window.removeEventListener('offline', onChange);
+    };
+  }, []);
+
+  if (online && pendingActions.length === 0) {
+    return (
+      <div className="fixed bottom-2 left-1/2 -translate-x-1/2 flex items-center gap-2 rounded-md bg-green-600 px-3 py-1 text-sm text-white shadow">
+        <CheckCircle2 className="h-4 w-4" />
+        Synced
+      </div>
+    );
+  }
+
+  if (!online) {
+    return (
+      <div className="fixed bottom-2 left-1/2 -translate-x-1/2 flex items-center gap-2 rounded-md bg-yellow-500 px-3 py-1 text-sm text-black shadow">
+        <AlertCircle className="h-4 w-4" />
+        Offline Mode: {pendingActions.length} actions pending
+      </div>
+    );
+  }
+
+  if (pendingActions.length > 0) {
+    return (
+      <div className="fixed bottom-2 left-1/2 -translate-x-1/2 flex items-center gap-2 rounded-md bg-blue-600 px-3 py-1 text-sm text-white shadow">
+        Syncing {pendingActions.length} actions...
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/context/offline-queue.tsx
+++ b/src/context/offline-queue.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+
+export type QueuedActionType = 'check-in' | 'complete-task' | 'log-expense';
+
+export interface QueuedAction {
+  id: string;
+  type: QueuedActionType;
+  payload: any;
+  timestamp: number;
+}
+
+interface OfflineQueueContextType {
+  pendingActions: QueuedAction[];
+  enqueue: (action: Omit<QueuedAction, 'id' | 'timestamp'>) => void;
+  registerExecutor: (type: QueuedActionType, fn: (payload: any) => Promise<void>) => void;
+}
+
+const OfflineQueueContext = createContext<OfflineQueueContextType | undefined>(undefined);
+
+const STORAGE_KEY = 'fieldops_offline_queue';
+
+export function OfflineQueueProvider({ children }: { children: React.ReactNode }) {
+  const [pendingActions, setPendingActions] = useState<QueuedAction[]>([]);
+  const executorsRef = useRef<Record<QueuedActionType, (payload: any) => Promise<void>>>({
+    'check-in': async () => {},
+    'complete-task': async () => {},
+    'log-expense': async () => {},
+  });
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        setPendingActions(JSON.parse(raw));
+      }
+    } catch (e) {
+      console.warn('Failed to load offline queue', e);
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(pendingActions));
+    } catch (e) {
+      console.warn('Failed to save offline queue', e);
+    }
+  }, [pendingActions]);
+
+  useEffect(() => {
+    async function processQueue() {
+      if (!navigator.onLine || pendingActions.length === 0) return;
+      for (const action of [...pendingActions]) {
+        const executor = executorsRef.current[action.type];
+        if (!executor) continue;
+        try {
+          await executor(action.payload);
+          setPendingActions(q => q.filter(a => a.id !== action.id));
+        } catch (err) {
+          console.error('Failed to process queued action', err);
+          break;
+        }
+      }
+    }
+    const interval = setInterval(processQueue, 10000);
+    window.addEventListener('online', processQueue);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener('online', processQueue);
+    };
+  }, [pendingActions]);
+
+  const enqueue = (action: Omit<QueuedAction, 'id' | 'timestamp'>) => {
+    const finalAction: QueuedAction = { ...action, id: crypto.randomUUID(), timestamp: Date.now() };
+    if (navigator.onLine) {
+      const executor = executorsRef.current[action.type];
+      if (executor) {
+        executor(action.payload).catch(() => {
+          setPendingActions(q => [...q, finalAction]);
+        });
+      } else {
+        setPendingActions(q => [...q, finalAction]);
+      }
+    } else {
+      setPendingActions(q => [...q, finalAction]);
+    }
+  };
+
+  const registerExecutor = (type: QueuedActionType, fn: (payload: any) => Promise<void>) => {
+    executorsRef.current[type] = fn;
+  };
+
+  return (
+    <OfflineQueueContext.Provider value={{ pendingActions, enqueue, registerExecutor }}>
+      {children}
+    </OfflineQueueContext.Provider>
+  );
+}
+
+export function useOfflineQueue() {
+  const ctx = useContext(OfflineQueueContext);
+  if (!ctx) throw new Error('useOfflineQueue must be used within OfflineQueueProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add offline queue context and provider
- show offline/sync status banner
- wrap app with provider

## Testing
- `npm run typecheck` *(fails: cannot find modules)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441f79b89c83209d054627ed36236a