### PR TITLE
Add stale task detection

### DIFF
--- a/src/app/actions/admin/fetchStaleTasks.ts
+++ b/src/app/actions/admin/fetchStaleTasks.ts
@@ -1,0 +1,68 @@
+'use server';
+
+import { db } from '@/lib/firebase';
+import { collection, getDocs, query, where, Timestamp } from 'firebase/firestore';
+import type { Task } from '@/types/database';
+import { getUserDisplayName, getProjectName } from '@/app/actions/notificationsUtils';
+
+export interface StaleTaskInfo {
+  id: string;
+  taskName: string;
+  projectId: string;
+  projectName: string;
+  assignedEmployeeId: string;
+  assignedEmployeeName: string;
+  supervisorId: string;
+  supervisorName: string;
+  createdAt: string;
+}
+
+/**
+ * Fetch tasks that are still pending with no start time and were created
+ * before the given threshold (defaults to 48 hours ago).
+ */
+export async function fetchStaleTasks(thresholdHours: number = 48): Promise<StaleTaskInfo[]> {
+  const cutoffDate = new Date(Date.now() - thresholdHours * 60 * 60 * 1000);
+
+  try {
+    const tasksRef = collection(db, 'tasks');
+    const q = query(
+      tasksRef,
+      where('status', '==', 'pending'),
+      where('createdAt', '<', Timestamp.fromDate(cutoffDate))
+    );
+
+    const snapshot = await getDocs(q);
+    const results: StaleTaskInfo[] = [];
+
+    for (const docSnap of snapshot.docs) {
+      const data = docSnap.data() as Task;
+      if (data.startTime != null) continue; // Task already started
+
+      const createdAt = data.createdAt instanceof Timestamp
+        ? data.createdAt.toDate().toISOString()
+        : (typeof data.createdAt === 'string' ? data.createdAt : new Date(0).toISOString());
+
+      const employeeName = await getUserDisplayName(data.assignedEmployeeId);
+      const supervisorName = await getUserDisplayName(data.createdBy);
+      const projectName = await getProjectName(data.projectId);
+
+      results.push({
+        id: docSnap.id,
+        taskName: data.taskName || 'Unnamed Task',
+        projectId: data.projectId,
+        projectName,
+        assignedEmployeeId: data.assignedEmployeeId,
+        assignedEmployeeName: employeeName,
+        supervisorId: data.createdBy,
+        supervisorName,
+        createdAt,
+      });
+    }
+
+    return results;
+  } catch (error) {
+    console.error('Error fetching stale tasks:', error);
+    return [];
+  }
+}

--- a/src/app/dashboard/admin/reports/page.tsx
+++ b/src/app/dashboard/admin/reports/page.tsx
@@ -3,6 +3,7 @@
 
 import { PageHeader } from "@/components/shared/page-header";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import Link from "next/link";
 import { Download } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -38,6 +39,20 @@ export default function GlobalReportsPage() {
           <p className="text-muted-foreground">
             Summary reports on attendance records, anomaly rates, and overall compliance scores.
           </p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle className="font-headline">Stale Tasks Report</CardTitle>
+          <CardDescription>Identify tasks assigned but never started.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p className="text-muted-foreground">
+            Review tasks that remain in the pending state for more than two days.
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/dashboard/admin/reports/stale-tasks">View Report</Link>
+          </Button>
         </CardContent>
       </Card>
     </div>

--- a/src/app/dashboard/admin/reports/stale-tasks/page.tsx
+++ b/src/app/dashboard/admin/reports/stale-tasks/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { PageHeader } from "@/components/shared/page-header";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Table, TableHead, TableHeader, TableRow, TableCell, TableBody } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { RefreshCw } from "lucide-react";
+import { format } from "date-fns";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/context/auth-context";
+import { fetchStaleTasks, type StaleTaskInfo } from "@/app/actions/admin/fetchStaleTasks";
+
+export default function StaleTasksReportPage() {
+  const { user, loading } = useAuth();
+  const { toast } = useToast();
+  const [tasks, setTasks] = useState<StaleTaskInfo[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const loadTasks = useCallback(async () => {
+    if (!user?.id) {
+      if (!loading) {
+        toast({ title: "Authentication Error", description: "Admin user not found.", variant: "destructive" });
+      }
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const results = await fetchStaleTasks();
+      setTasks(results);
+    } catch (err) {
+      console.error("Error fetching stale tasks:", err);
+      toast({ title: "Failed to fetch tasks", description: "An error occurred.", variant: "destructive" });
+      setTasks([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [user?.id, loading, toast]);
+
+  useEffect(() => {
+    if (!loading) {
+      loadTasks();
+    }
+  }, [loading, loadTasks]);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Stale Tasks"
+        description="Tasks assigned but not started in over 48 hours."
+        actions={
+          <Button onClick={loadTasks} variant="outline">
+            <RefreshCw className={`mr-2 h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} /> Refresh
+          </Button>
+        }
+      />
+      <Card>
+        <CardHeader>
+          <CardTitle className="font-headline">Stale Tasks</CardTitle>
+          <CardDescription>
+            {tasks.length > 0 ? `Found ${tasks.length} task(s) pending start.` : "No stale tasks found."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0 overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Task</TableHead>
+                <TableHead>Employee</TableHead>
+                <TableHead>Project</TableHead>
+                <TableHead>Supervisor</TableHead>
+                <TableHead>Assigned</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {tasks.map(task => (
+                <TableRow key={task.id}>
+                  <TableCell>{task.taskName}</TableCell>
+                  <TableCell>{task.assignedEmployeeName}</TableCell>
+                  <TableCell>{task.projectName}</TableCell>
+                  <TableCell>{task.supervisorName}</TableCell>
+                  <TableCell>{format(new Date(task.createdAt), 'PP')}</TableCell>
+                </TableRow>
+              ))}
+              {tasks.length === 0 && !isLoading && (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center py-6 text-muted-foreground">
+                    No stale tasks found.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- fetch tasks older than two days that never started
- show stale tasks report in admin dashboard
- link stale tasks report from Global Reports

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68454c0622b883209c277c2afeddd6f9