### PR TITLE
Add important task flag

### DIFF
--- a/src/app/actions/employee/fetchEmployeeData.ts
+++ b/src/app/actions/employee/fetchEmployeeData.ts
@@ -191,6 +191,8 @@ export async function fetchMyTasksForProject(employeeId: string, projectId: stri
         aiComplianceNotes: data.aiComplianceNotes || '',
         aiRisks: data.aiRisks || [],
 
+        isImportant: data.isImportant || false,
+
         supervisorReviewNotes: data.supervisorReviewNotes || '',
         reviewedBy: data.reviewedBy || '',
         reviewedAt: convertTimestampToMillis(data.reviewedAt),

--- a/src/app/actions/supervisor/assignTask.ts
+++ b/src/app/actions/supervisor/assignTask.ts
@@ -15,6 +15,7 @@ const AssignTaskSchema = z.object({
   description: z.string().max(500).optional(),
   dueDate: z.date({ required_error: 'Due date is required.' }),
   supervisorNotes: z.string().max(500).optional(),
+  isImportant: z.boolean().optional().default(false),
 });
 
 export type AssignTaskInput = z.infer<typeof AssignTaskSchema>;
@@ -36,7 +37,7 @@ export async function assignTask(supervisorId: string, input: AssignTaskInput): 
     return { success: false, message: 'Invalid input.', errors: validationResult.error.issues };
   }
 
-  const { employeeId, projectId, taskName, description, dueDate, supervisorNotes } = validationResult.data;
+  const { employeeId, projectId, taskName, description, dueDate, supervisorNotes, isImportant } = validationResult.data;
 
   try {
     // Optional: Validate if employeeId and projectId actually exist
@@ -63,9 +64,10 @@ export async function assignTask(supervisorId: string, input: AssignTaskInput): 
       taskName,
       description: description || '',
       projectId,
-      assignedEmployeeId: employeeId, 
+      assignedEmployeeId: employeeId,
       dueDate: dueDate.toISOString(),
       supervisorNotes: supervisorNotes || '',
+      isImportant: !!isImportant,
       status: 'pending',
       createdBy: supervisorId,
       createdAt: serverTimestamp(),

--- a/src/app/dashboard/employee/projects/[projectId]/tasks/page.tsx
+++ b/src/app/dashboard/employee/projects/[projectId]/tasks/page.tsx
@@ -72,7 +72,9 @@ export default function EmployeeTasksPage() {
       console.log("[EmployeeTasksPage] Raw result from fetchMyTasksForProject:", fetchedTasksResult);
       
       setProjectDetails(fetchedProjectDetailsResult);
-      setTasks(fetchedTasksResult.map(task => ({ ...task, elapsedTime: task.elapsedTime || 0 })));
+      const processed = fetchedTasksResult.map(task => ({ ...task, elapsedTime: task.elapsedTime || 0 }));
+      processed.sort((a,b) => (b.isImportant ? 1 : 0) - (a.isImportant ? 1 : 0));
+      setTasks(processed);
       console.log("[EmployeeTasksPage] Processed fetched tasks for state (length):", fetchedTasksResult.length, "Full data:", JSON.parse(JSON.stringify(fetchedTasksResult)));
 
     } catch (error) {
@@ -321,7 +323,10 @@ export default function EmployeeTasksPage() {
             <Card key={task.id} className="flex flex-col shadow-lg hover:shadow-xl transition-shadow duration-300">
               <CardHeader>
                 <div className="flex justify-between items-start">
-                  <CardTitle className="font-headline text-xl">{task.taskName}</CardTitle>
+                  <CardTitle className="font-headline text-xl flex items-center gap-2">
+                    {task.taskName}
+                    {task.isImportant && <Badge variant="destructive">Important</Badge>}
+                  </CardTitle>
                   <Badge variant={
                     task.status === 'completed' || task.status === 'verified' ? 'default' :
                     task.status === 'in-progress' ? 'secondary' :

--- a/src/app/dashboard/supervisor/assign-task/page.tsx
+++ b/src/app/dashboard/supervisor/assign-task/page.tsx
@@ -12,6 +12,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
 import { CalendarIcon, User, Briefcase, FileText, PlusCircle, MessageSquare, RefreshCw } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
 import { format } from "date-fns";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from '@/context/auth-context'; 
@@ -32,6 +33,7 @@ export default function AssignTaskPage() {
   const [taskDescription, setTaskDescription] = useState('');
   const [supervisorNotes, setSupervisorNotes] = useState('');
   const [dueDate, setDueDate] = useState<Date | undefined>(undefined);
+  const [isImportant, setIsImportant] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<Record<string, string | undefined>>({});
   const { toast } = useToast();
@@ -70,6 +72,7 @@ export default function AssignTaskPage() {
     setTaskDescription('');
     setSupervisorNotes('');
     setDueDate(undefined);
+    setIsImportant(false);
     setErrors({});
   };
 
@@ -98,6 +101,7 @@ export default function AssignTaskPage() {
       description: taskDescription || undefined,
       dueDate,
       supervisorNotes: supervisorNotes || undefined,
+      isImportant,
     };
 
     const result: AssignTaskResult = await assignTask(user.id, taskInput);
@@ -265,6 +269,11 @@ export default function AssignTaskPage() {
                 </PopoverContent>
               </Popover>
               {errors.dueDate && <p className="text-sm text-destructive mt-1">{errors.dueDate}</p>}
+            </div>
+
+            <div className="flex items-center space-x-2">
+              <Checkbox id="important" checked={isImportant} onCheckedChange={v => setIsImportant(!!v)} />
+              <Label htmlFor="important">Mark as Important</Label>
             </div>
 
             <div className="pt-2">

--- a/src/context/auth-context.tsx
+++ b/src/context/auth-context.tsx
@@ -89,6 +89,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         localStorage.removeItem('fieldops_user');
       }
       setLoading(false);
+      } catch (error) {
+        console.error('Auth state change error:', error);
+        setUser(null);
+        setLoading(false);
+      }
     });
 
     return () => unsubscribe();

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -83,6 +83,9 @@ export interface Task {
   createdBy: string; // Supervisor/Admin UID
   supervisorNotes?: string;
 
+  /** Whether this task is marked as important */
+  isImportant?: boolean;
+
   employeeNotes?: string;
   submittedMediaUri?: string;
 


### PR DESCRIPTION
## Summary
- highlight important tasks and allow flagging when assigning
- map `isImportant` from Firestore data
- sort tasks so important ones appear first
- fix missing catch in auth context

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845542e1b30832091e9c627b173e6f3