### PR TITLE
Add expo mobile scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+**/node_modules
 /.pnp
 .pnp.*
 .yarn/*

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import { AuthProvider, useAuth } from './src/context/auth-context';
+
+function HomeScreen() {
+  const { user, loading } = useAuth();
+  if (loading) return <Text>Loading...</Text>;
+  return <Text>{user ? `Logged in as ${user.email}` : 'Not authenticated'}</Text>;
+}
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <View style={styles.container}>
+        <HomeScreen />
+        <StatusBar style="auto" />
+      </View>
+    </AuthProvider>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,37 @@
+# FieldOps Mobile
+
+This directory contains the starting point for the mobile version of **FieldOps**. It uses [Expo](https://expo.dev/) and React Native. The code is intentionally minimal and should be expanded to match the full Next.js functionality.
+
+## Setup
+
+1. Install dependencies:
+
+   ```bash
+   cd mobile
+   npm install
+   ```
+
+2. Provide Firebase configuration using Expo environment variables. Create a file named `.env` in `mobile/` with the following keys:
+
+   ```
+   EXPO_PUBLIC_FIREBASE_API_KEY=your_key
+   EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN=your_domain
+   EXPO_PUBLIC_FIREBASE_PROJECT_ID=your_project_id
+   EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET=your_bucket
+   EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+   EXPO_PUBLIC_FIREBASE_APP_ID=your_app_id
+   ```
+
+3. Start the development server:
+
+   ```bash
+   npm start
+   ```
+
+Expo will guide you to open the app on Android, iOS, or the web.
+
+## Notes
+
+- `src/lib/firebase.ts` initializes Firebase using values from `app.config.js`.
+- `src/context/auth-context.tsx` implements a simplified authentication context using `AsyncStorage`.
+- This scaffold only covers authentication and Firebase setup; replicate the remaining Next.js functionality (tasks, offline queue, etc.) as needed.

--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -1,0 +1,14 @@
+export default {
+  name: 'FieldOpsMobile',
+  slug: 'fieldops-mobile',
+  version: '1.0.0',
+  sdkVersion: '50.0.0',
+  extra: {
+    firebaseApiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
+    firebaseAuthDomain: process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    firebaseProjectId: process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID,
+    firebaseStorageBucket: process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    firebaseMessagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+    firebaseAppId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID,
+  },
+};

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "fieldops-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "expo-status-bar": "~1.11.1",
+    "firebase": "^11.8.1",
+    "react": "18.2.0",
+    "react-native": "0.73.4",
+    "@react-native-async-storage/async-storage": "^1.21.0",
+    "expo-constants": "^15.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/mobile/src/context/auth-context.tsx
+++ b/mobile/src/context/auth-context.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useState, useEffect, useContext } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { onAuthStateChanged, User as FirebaseUser } from 'firebase/auth';
+import { auth } from '../lib/firebase';
+
+export interface User {
+  id: string;
+  email: string | null;
+}
+
+interface AuthContextType {
+  user: User | null;
+  loading: boolean;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const sub = onAuthStateChanged(auth, async (firebaseUser: FirebaseUser | null) => {
+      if (firebaseUser) {
+        const appUser: User = { id: firebaseUser.uid, email: firebaseUser.email };
+        setUser(appUser);
+        await AsyncStorage.setItem('fieldops_user', JSON.stringify(appUser));
+      } else {
+        setUser(null);
+        await AsyncStorage.removeItem('fieldops_user');
+      }
+      setLoading(false);
+    });
+    return () => sub();
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/mobile/src/lib/firebase.ts
+++ b/mobile/src/lib/firebase.ts
@@ -1,0 +1,23 @@
+import { initializeApp, getApps, getApp, FirebaseApp } from 'firebase/app';
+import { getAuth, Auth } from 'firebase/auth';
+import { getFirestore, Firestore } from 'firebase/firestore';
+import Constants from 'expo-constants';
+
+const firebaseConfigValues = {
+  apiKey: Constants.expoConfig?.extra?.firebaseApiKey,
+  authDomain: Constants.expoConfig?.extra?.firebaseAuthDomain,
+  projectId: Constants.expoConfig?.extra?.firebaseProjectId,
+  storageBucket: Constants.expoConfig?.extra?.firebaseStorageBucket,
+  messagingSenderId: Constants.expoConfig?.extra?.firebaseMessagingSenderId,
+  appId: Constants.expoConfig?.extra?.firebaseAppId,
+};
+
+let app: FirebaseApp;
+if (!getApps().length) {
+  app = initializeApp(firebaseConfigValues);
+} else {
+  app = getApp();
+}
+
+export const auth: Auth = getAuth(app);
+export const db: Firestore = getFirestore(app);

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "esnext",
+    "jsx": "react",
+    "strict": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- start an Expo project under `mobile` for the planned mobile app
- initialize Firebase for React Native
- provide a basic authentication context
- document setup steps
- ignore nested `node_modules`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684725a3b9d88320951a2b5b0b19cb40