### PR TITLE
Add admin system config

### DIFF
--- a/src/app/actions/admin/getSystemConfig.ts
+++ b/src/app/actions/admin/getSystemConfig.ts
@@ -1,0 +1,26 @@
+'use server';
+
+import { db } from '@/lib/firebase';
+import { doc, getDoc } from 'firebase/firestore';
+import type { SystemConfig } from '@/types/database';
+
+export interface GetSystemConfigResult {
+  success: boolean;
+  config?: SystemConfig;
+  error?: string;
+}
+
+export async function getSystemConfig(): Promise<GetSystemConfigResult> {
+  try {
+    const configDocRef = doc(db, 'config', 'system');
+    const snap = await getDoc(configDocRef);
+    if (snap.exists()) {
+      return { success: true, config: { id: snap.id, ...(snap.data() as Omit<SystemConfig, 'id'>) } };
+    }
+    return { success: true, config: { id: configDocRef.id } };
+  } catch (error) {
+    console.error('Error fetching system config:', error);
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    return { success: false, error: `Failed to fetch config: ${msg}` };
+  }
+}

--- a/src/app/actions/admin/updateSystemConfig.ts
+++ b/src/app/actions/admin/updateSystemConfig.ts
@@ -1,0 +1,45 @@
+'use server';
+
+import { db } from '@/lib/firebase';
+import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
+import { z } from 'zod';
+
+export const UpdateSystemConfigSchema = z.object({
+  mapboxApiKey: z.string().optional(),
+  openAiApiKey: z.string().optional(),
+});
+
+export type UpdateSystemConfigInput = z.infer<typeof UpdateSystemConfigSchema>;
+
+export interface UpdateSystemConfigResult {
+  success: boolean;
+  message: string;
+  errors?: z.ZodIssue[];
+}
+
+export async function updateSystemConfig(
+  input: UpdateSystemConfigInput
+): Promise<UpdateSystemConfigResult> {
+  const parsed = UpdateSystemConfigSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: 'Invalid input.',
+      errors: parsed.error.issues,
+    };
+  }
+
+  try {
+    const configDocRef = doc(db, 'config', 'system');
+    await setDoc(
+      configDocRef,
+      { ...parsed.data, updatedAt: serverTimestamp() },
+      { merge: true }
+    );
+    return { success: true, message: 'Configuration updated successfully.' };
+  } catch (error) {
+    console.error('Error updating system config:', error);
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    return { success: false, message: `Failed to update config: ${msg}` };
+  }
+}

--- a/src/app/dashboard/admin/system-settings/page.tsx
+++ b/src/app/dashboard/admin/system-settings/page.tsx
@@ -1,43 +1,72 @@
 
 "use client";
 
+import { useEffect, useState } from "react";
 import { PageHeader } from "@/components/shared/page-header";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Save } from "lucide-react";
+import { getSystemConfig } from "@/app/actions/admin/getSystemConfig";
+import { updateSystemConfig } from "@/app/actions/admin/updateSystemConfig";
+import { useToast } from "@/hooks/use-toast";
 
 export default function SystemSettingsPage() {
+  const [mapboxKey, setMapboxKey] = useState("");
+  const [openAiKey, setOpenAiKey] = useState("");
+  const [loading, setLoading] = useState(true);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      const result = await getSystemConfig();
+      if (result.success && result.config) {
+        setMapboxKey(result.config.mapboxApiKey || "");
+        setOpenAiKey(result.config.openAiApiKey || "");
+      } else if (!result.success) {
+        toast({ title: "Error", description: result.error || "Could not load config.", variant: "destructive" });
+      }
+      setLoading(false);
+    };
+    load();
+  }, [toast]);
+
+  const handleSave = async () => {
+    const result = await updateSystemConfig({ mapboxApiKey: mapboxKey, openAiApiKey: openAiKey });
+    if (result.success) {
+      toast({ title: "Config Saved", description: result.message });
+    } else {
+      toast({ title: "Error", description: result.message, variant: "destructive" });
+    }
+  };
+
   return (
     <div className="space-y-6">
-      <PageHeader 
-        title="System Settings" 
+      <PageHeader
+        title="System Settings"
         description="Configure global application parameters."
         actions={
-          <Button className="bg-accent hover:bg-accent/90 text-accent-foreground">
+          <Button onClick={handleSave} className="bg-accent hover:bg-accent/90 text-accent-foreground">
             <Save className="mr-2 h-4 w-4" /> Save Changes
           </Button>
         }
       />
       <Card>
         <CardHeader>
-          <CardTitle className="font-headline">General Settings</CardTitle>
-          <CardDescription>Application name, default timezone, etc. (Placeholder)</CardDescription>
+          <CardTitle className="font-headline">API Keys</CardTitle>
+          <CardDescription>Manage third-party service keys used by the application.</CardDescription>
         </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground">
-            Forms for various system settings (e.g., GPS verification radius, notification preferences, API keys) will be implemented here.
-          </p>
-        </CardContent>
-      </Card>
-       <Card>
-        <CardHeader>
-          <CardTitle className="font-headline">Compliance Settings</CardTitle>
-          <CardDescription>Parameters for AI compliance checks. (Placeholder)</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground">
-            Settings related to compliance rules, thresholds, and AI model configurations.
-          </p>
+        <CardContent className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="mapbox">Mapbox API Key</Label>
+            <Input id="mapbox" value={mapboxKey} onChange={(e) => setMapboxKey(e.target.value)} disabled={loading} />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="openai">OpenAI API Key</Label>
+            <Input id="openai" value={openAiKey} onChange={(e) => setOpenAiKey(e.target.value)} disabled={loading} />
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -280,4 +280,16 @@ export interface Notification {
   read: boolean;
   createdAt: Timestamp;
 }
+
+/**
+ * Represents application wide configuration parameters that can be updated by administrators. In a real deployment sensitive values would be stored
+ * securely on the server, but for this demo they live in Firestore.
+ * Documents are stored in the `config` collection with a single `system` doc.
+ */
+export interface SystemConfig {
+  id: string;
+  mapboxApiKey?: string;
+  openAiApiKey?: string;
+  updatedAt?: Timestamp | string;
+}
 // ----- END PAYROLL MODULE TYPES -----


### PR DESCRIPTION
## Summary
- add `SystemConfig` type
- create admin actions to load and save config in Firestore
- implement editable form for API keys under Admin System Settings

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_685588a6a43c8320b0a70c874d23791c