### PR TITLE
Add task completion report

### DIFF
--- a/src/app/actions/admin/fetchTaskCompletionReport.ts
+++ b/src/app/actions/admin/fetchTaskCompletionReport.ts
@@ -1,0 +1,70 @@
+'use server';
+
+import { db } from '@/lib/firebase';
+import { collection, query, where, getCountFromServer } from 'firebase/firestore';
+import type { TaskStatus } from '@/types/database';
+
+export interface TaskCompletionStats {
+  totalTasks: number;
+  completedTasks: number;
+  inProgressTasks: number;
+  pendingTasks: number;
+  needsReviewTasks: number;
+  rejectedTasks: number;
+}
+
+export interface FetchTaskCompletionReportResult {
+  success: boolean;
+  stats?: TaskCompletionStats;
+  error?: string;
+}
+
+/**
+ * Fetch aggregated task completion statistics across all projects.
+ */
+export async function fetchTaskCompletionReport(): Promise<FetchTaskCompletionReportResult> {
+  try {
+    const tasksRef = collection(db, 'tasks');
+
+    const statusList: TaskStatus[] = [
+      'completed',
+      'verified',
+      'in-progress',
+      'pending',
+      'needs-review',
+      'rejected',
+    ];
+
+    const counts: Record<TaskStatus, number> = {
+      'completed': 0,
+      'verified': 0,
+      'in-progress': 0,
+      'pending': 0,
+      'needs-review': 0,
+      'rejected': 0,
+    };
+
+    for (const status of statusList) {
+      const q = query(tasksRef, where('status', '==', status));
+      const snap = await getCountFromServer(q);
+      counts[status] = snap.data().count;
+    }
+
+    const totalSnap = await getCountFromServer(tasksRef);
+
+    const stats: TaskCompletionStats = {
+      totalTasks: totalSnap.data().count,
+      completedTasks: counts['completed'] + counts['verified'],
+      inProgressTasks: counts['in-progress'],
+      pendingTasks: counts['pending'],
+      needsReviewTasks: counts['needs-review'],
+      rejectedTasks: counts['rejected'],
+    };
+
+    return { success: true, stats };
+  } catch (error) {
+    console.error('Error generating task completion report:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return { success: false, error: message };
+  }
+}

--- a/src/app/dashboard/admin/reports/page.tsx
+++ b/src/app/dashboard/admin/reports/page.tsx
@@ -22,12 +22,15 @@ export default function GlobalReportsPage() {
       <Card>
         <CardHeader>
           <CardTitle className="font-headline">Overall Task Completion Report</CardTitle>
-          <CardDescription>(Placeholder)</CardDescription>
+          <CardDescription>View completion stats for all tasks.</CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-2">
           <p className="text-muted-foreground">
-            Charts and data tables showing task completion rates, average times, etc., across all projects and employees.
+            Charts and data tables showing completion rates and progress across all projects.
           </p>
+          <Button asChild variant="outline">
+            <Link href="/dashboard/admin/reports/task-completion">View Report</Link>
+          </Button>
         </CardContent>
       </Card>
       <Card>

--- a/src/app/dashboard/admin/reports/task-completion/page.tsx
+++ b/src/app/dashboard/admin/reports/task-completion/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { PageHeader } from "@/components/shared/page-header";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { RefreshCw } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { fetchTaskCompletionReport, type TaskCompletionStats } from "@/app/actions/admin/fetchTaskCompletionReport";
+
+export default function TaskCompletionReportPage() {
+  const { toast } = useToast();
+  const [stats, setStats] = useState<TaskCompletionStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const loadStats = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const result = await fetchTaskCompletionReport();
+      if (result.success && result.stats) {
+        setStats(result.stats);
+      } else {
+        setStats(null);
+        toast({ title: "Error", description: result.error || "Failed to load report.", variant: "destructive" });
+      }
+    } catch (error) {
+      console.error("Error loading task completion report:", error);
+      setStats(null);
+      toast({ title: "Error", description: "An unexpected error occurred.", variant: "destructive" });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
+  const completionPercentage = stats && stats.totalTasks > 0
+    ? (stats.completedTasks / stats.totalTasks) * 100
+    : 0;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Task Completion Report"
+        description="Overview of task status distribution across all projects."
+        actions={
+          <Button onClick={loadStats} variant="outline" disabled={isLoading}>
+            <RefreshCw className={`mr-2 h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        }
+      />
+      <Card>
+        <CardHeader>
+          <CardTitle className="font-headline">Overall Status Summary</CardTitle>
+          {stats && <CardDescription>Total Tasks: {stats.totalTasks}</CardDescription>}
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isLoading || !stats ? (
+            <p className="text-center text-muted-foreground py-6">{isLoading ? 'Loading...' : 'No data available.'}</p>
+          ) : (
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Completed / Verified</span>
+                <Badge className="bg-green-500 text-white hover:bg-green-600">{stats.completedTasks}</Badge>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">In Progress</span>
+                <Badge className="bg-blue-500 text-white hover:bg-blue-600">{stats.inProgressTasks}</Badge>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Pending</span>
+                <Badge variant="outline">{stats.pendingTasks}</Badge>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Needs Review</span>
+                <Badge className="border-yellow-500 text-yellow-600 hover:bg-yellow-500/10">{stats.needsReviewTasks}</Badge>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Rejected</span>
+                <Badge variant="destructive">{stats.rejectedTasks}</Badge>
+              </div>
+              <div className="pt-2">
+                <div className="flex justify-between text-sm mb-1">
+                  <span>Completion:</span>
+                  <span className="font-semibold">{completionPercentage.toFixed(1)}%</span>
+                </div>
+                <Progress value={completionPercentage} aria-label={`${completionPercentage.toFixed(1)}% completed`} />
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add server action to aggregate task completion stats
- implement admin page showing overall task completion with progress display
- link the new report from the reports dashboard

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685588e829e48320afe403a27edcb238