### PR TITLE
Implement global admin reports

### DIFF
--- a/src/app/actions/admin/fetchGlobalSummaries.ts
+++ b/src/app/actions/admin/fetchGlobalSummaries.ts
@@ -1,0 +1,121 @@
+'use server';
+
+import { db } from '@/lib/firebase';
+import { collection, getDocs } from 'firebase/firestore';
+import type { TaskStatus, AttendanceReviewStatus } from '@/types/database';
+
+export interface GlobalTaskCompletionSummary {
+  totalTasks: number;
+  completedTasks: number;
+  verifiedTasks: number;
+  inProgressTasks: number;
+  pendingTasks: number;
+  needsReviewTasks: number;
+  rejectedTasks: number;
+  completionPercentage: number;
+}
+
+export interface GlobalAttendanceSummary {
+  totalLogs: number;
+  checkedIn: number;
+  checkedOut: number;
+  pendingReview: number;
+  approved: number;
+  rejected: number;
+}
+
+export async function fetchGlobalTaskCompletionSummary(): Promise<GlobalTaskCompletionSummary> {
+  const tasksRef = collection(db, 'tasks');
+  const snapshot = await getDocs(tasksRef);
+
+  let total = 0,
+    completed = 0,
+    verified = 0,
+    inProgress = 0,
+    pending = 0,
+    needsReview = 0,
+    rejected = 0;
+
+  snapshot.forEach(docSnap => {
+    total += 1;
+    const status = docSnap.data().status as TaskStatus;
+    switch (status) {
+      case 'completed':
+        completed += 1;
+        break;
+      case 'verified':
+        verified += 1;
+        break;
+      case 'in-progress':
+        inProgress += 1;
+        break;
+      case 'pending':
+        pending += 1;
+        break;
+      case 'needs-review':
+        needsReview += 1;
+        break;
+      case 'rejected':
+        rejected += 1;
+        break;
+    }
+  });
+
+  const completionCount = completed + verified;
+  const percentage = total > 0 ? (completionCount / total) * 100 : 0;
+
+  return {
+    totalTasks: total,
+    completedTasks: completed,
+    verifiedTasks: verified,
+    inProgressTasks: inProgress,
+    pendingTasks: pending,
+    needsReviewTasks: needsReview,
+    rejectedTasks: rejected,
+    completionPercentage: parseFloat(percentage.toFixed(1)),
+  };
+}
+
+export async function fetchGlobalAttendanceSummary(): Promise<GlobalAttendanceSummary> {
+  const attendanceRef = collection(db, 'attendanceLogs');
+  const snapshot = await getDocs(attendanceRef);
+
+  let total = 0,
+    checkedIn = 0,
+    checkedOut = 0,
+    pendingReview = 0,
+    approved = 0,
+    rejected = 0;
+
+  snapshot.forEach(docSnap => {
+    total += 1;
+    const data = docSnap.data();
+    if (data.checkOutTime) {
+      checkedOut += 1;
+    } else if (data.checkInTime) {
+      checkedIn += 1;
+    }
+
+    const status = (data.reviewStatus || 'pending') as AttendanceReviewStatus;
+    switch (status) {
+      case 'approved':
+        approved += 1;
+        break;
+      case 'rejected':
+        rejected += 1;
+        break;
+      default:
+        pendingReview += 1;
+        break;
+    }
+  });
+
+  return {
+    totalLogs: total,
+    checkedIn,
+    checkedOut,
+    pendingReview,
+    approved,
+    rejected,
+  };
+}

--- a/src/app/dashboard/admin/reports/page.tsx
+++ b/src/app/dashboard/admin/reports/page.tsx
@@ -1,17 +1,40 @@
 
 "use client";
 
+import { useEffect, useState } from "react";
 import { PageHeader } from "@/components/shared/page-header";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import Link from "next/link";
-import { Download } from "lucide-react";
+import { Download, CheckCircle, ListChecks, Clock, Hourglass, AlertTriangle, UserCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
+import { fetchGlobalTaskCompletionSummary, fetchGlobalAttendanceSummary, type GlobalTaskCompletionSummary, type GlobalAttendanceSummary } from "@/app/actions/admin/fetchGlobalSummaries";
 
 export default function GlobalReportsPage() {
+  const [taskSummary, setTaskSummary] = useState<GlobalTaskCompletionSummary | null>(null);
+  const [attendanceSummary, setAttendanceSummary] = useState<GlobalAttendanceSummary | null>(null);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const [taskRes, attendanceRes] = await Promise.all([
+          fetchGlobalTaskCompletionSummary(),
+          fetchGlobalAttendanceSummary(),
+        ]);
+        setTaskSummary(taskRes);
+        setAttendanceSummary(attendanceRes);
+      } catch (e) {
+        console.error('Failed to load global summaries', e);
+      }
+    };
+    loadData();
+  }, []);
+
   return (
     <div className="space-y-6">
-      <PageHeader 
-        title="Global Reports" 
+      <PageHeader
+        title="Global Reports"
         description="View and generate system-wide operational reports."
          actions={
           <Button variant="outline">
@@ -22,23 +45,58 @@ export default function GlobalReportsPage() {
       <Card>
         <CardHeader>
           <CardTitle className="font-headline">Overall Task Completion Report</CardTitle>
-          <CardDescription>(Placeholder)</CardDescription>
+          {taskSummary ? (
+            <CardDescription>{taskSummary.totalTasks} total tasks</CardDescription>
+          ) : (
+            <CardDescription>Loading...</CardDescription>
+          )}
         </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground">
-            Charts and data tables showing task completion rates, average times, etc., across all projects and employees.
-          </p>
+        <CardContent className="space-y-3">
+          {taskSummary ? (
+            <>
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div className="flex items-center justify-between"><span>Total</span><Badge variant="secondary">{taskSummary.totalTasks}</Badge></div>
+                <div className="flex items-center justify-between"><span className="flex items-center"><CheckCircle className="h-3 w-3 mr-1 text-green-600"/>Completed</span><Badge>{taskSummary.completedTasks}</Badge></div>
+                <div className="flex items-center justify-between"><span className="flex items-center"><ListChecks className="h-3 w-3 mr-1 text-green-600"/>Verified</span><Badge>{taskSummary.verifiedTasks}</Badge></div>
+                <div className="flex items-center justify-between"><span className="flex items-center"><Clock className="h-3 w-3 mr-1 text-blue-600"/>In Progress</span><Badge>{taskSummary.inProgressTasks}</Badge></div>
+                <div className="flex items-center justify-between"><span className="flex items-center"><Hourglass className="h-3 w-3 mr-1 text-orange-600"/>Pending</span><Badge>{taskSummary.pendingTasks}</Badge></div>
+                <div className="flex items-center justify-between"><span className="flex items-center"><AlertTriangle className="h-3 w-3 mr-1 text-yellow-600"/>Needs Review</span><Badge>{taskSummary.needsReviewTasks}</Badge></div>
+                <div className="flex items-center justify-between"><span className="flex items-center"><AlertTriangle className="h-3 w-3 mr-1 text-red-600"/>Rejected</span><Badge variant="destructive">{taskSummary.rejectedTasks}</Badge></div>
+              </div>
+              <div className="pt-2">
+                <div className="flex justify-between text-sm mb-1">
+                  <span>Completion</span>
+                  <span className="font-semibold">{taskSummary.completionPercentage.toFixed(1)}%</span>
+                </div>
+                <Progress value={taskSummary.completionPercentage} aria-label={`${taskSummary.completionPercentage.toFixed(1)}% completed`} />
+              </div>
+            </>
+          ) : (
+            <p className="text-muted-foreground">Loading task data...</p>
+          )}
         </CardContent>
       </Card>
       <Card>
         <CardHeader>
           <CardTitle className="font-headline">Attendance & Compliance Summary</CardTitle>
-          <CardDescription>(Placeholder)</CardDescription>
+          {attendanceSummary ? (
+            <CardDescription>{attendanceSummary.totalLogs} logs</CardDescription>
+          ) : (
+            <CardDescription>Loading...</CardDescription>
+          )}
         </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground">
-            Summary reports on attendance records, anomaly rates, and overall compliance scores.
-          </p>
+        <CardContent className="space-y-3 text-sm">
+          {attendanceSummary ? (
+            <>
+              <div className="flex justify-between"><span className="flex items-center"><UserCheck className="h-3 w-3 mr-1 text-blue-600"/>Checked In</span><Badge>{attendanceSummary.checkedIn}</Badge></div>
+              <div className="flex justify-between"><span className="flex items-center"><CheckCircle className="h-3 w-3 mr-1 text-green-600"/>Checked Out</span><Badge>{attendanceSummary.checkedOut}</Badge></div>
+              <div className="flex justify-between"><span className="flex items-center"><Hourglass className="h-3 w-3 mr-1 text-orange-600"/>Pending Review</span><Badge>{attendanceSummary.pendingReview}</Badge></div>
+              <div className="flex justify-between"><span className="flex items-center"><CheckCircle className="h-3 w-3 mr-1 text-green-600"/>Approved</span><Badge>{attendanceSummary.approved}</Badge></div>
+              <div className="flex justify-between"><span className="flex items-center"><AlertTriangle className="h-3 w-3 mr-1 text-red-600"/>Rejected</span><Badge variant="destructive">{attendanceSummary.rejected}</Badge></div>
+            </>
+          ) : (
+            <p className="text-muted-foreground">Loading attendance data...</p>
+          )}
         </CardContent>
       </Card>
       <Card>


### PR DESCRIPTION
## Summary
- add server actions to fetch global task and attendance data
- display real completion and attendance summaries in admin reports

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855891b9640832083ca09aa6434db59