### PR TITLE
Add WhatsApp and in‑app notifications

### DIFF
--- a/src/actions/admin/assignTask.ts
+++ b/src/actions/admin/assignTask.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { db } from '@/lib/firebase';
 import { doc, updateDoc, arrayUnion, getDoc, serverTimestamp, Timestamp } from 'firebase/firestore';
 import { notifyUserByWhatsApp } from '@/lib/notify';
-import { getUserDisplayName, getProjectName } from '@/app/actions/notificationsUtils';
+import { getUserDisplayName, getProjectName, createSingleNotification } from '@/app/actions/notificationsUtils';
 import type { Task, TaskStatus } from '@/types/database';
 import { format } from 'date-fns';
 import { createQuickTaskForAssignment, CreateQuickTaskInput, CreateQuickTaskResult } from './createTask'; // Import createQuickTask
@@ -155,6 +155,14 @@ export async function assignTasksToEmployee(supervisorId: string, input: AssignT
         const taskNameStr = taskToProcess.taskName;
         const waMessage = `\ud83d\udccb Task Assigned\nProject: ${projectNameStr}\nTask: ${taskNameStr}${taskToProcess.isImportant ? ' (\u26a0\ufe0f Important)' : ''}\nDue: ${format(dueDate, "PP")}\nBy: ${supervisorName}\nNotes: ${supervisorNotes || 'None'}`;
         await notifyUserByWhatsApp(employeeId, waMessage);
+        await createSingleNotification(
+          employeeId,
+          'task-assigned',
+          `Task Assigned: ${taskNameStr}`,
+          `You have been assigned the task "${taskNameStr}" in project "${projectNameStr}" due ${format(dueDate, 'PP')}.`,
+          taskToProcess.taskId,
+          'task'
+        );
 
       } catch (taskError: any) {
         console.error(`Error assigning task ${taskToProcess.taskId}:`, taskError);

--- a/src/app/actions/attendance.ts
+++ b/src/app/actions/attendance.ts
@@ -21,6 +21,7 @@ import {
 import type { AttendanceLog, User, Project, UserRole, AttendanceReviewStatus, Task } from '@/types/database';
 import { format, isValid, parseISO, startOfMonth, endOfMonth } from 'date-fns';
 import { createNotificationsForRole, getUserDisplayName, getProjectName } from '@/app/actions/notificationsUtils';
+import { notifyRoleByWhatsApp } from '@/lib/notify';
 
 interface ServerActionResult {
   success: boolean;
@@ -182,6 +183,10 @@ export async function logAttendance(
         await createNotificationsForRole('supervisor', 'attendance-log-review-needed', title, body, docRef.id, 'attendance_log');
         await createNotificationsForRole('admin', 'attendance-log-review-needed', `Admin: ${title}`, body, docRef.id, 'attendance_log');
 
+        const waMsg = `\u23f0 Attendance Check-In\nEmployee: ${employeeName}\nProject: ${projectName}\nTime: ${checkInFormattedTime}`;
+        await notifyRoleByWhatsApp('supervisor', waMsg, employeeId);
+        await notifyRoleByWhatsApp('admin', waMsg, employeeId);
+
         return {
             success: true,
             message: `Checked in successfully at ${checkInFormattedTime}.`,
@@ -332,6 +337,10 @@ export async function checkoutAttendance(
 
         await createNotificationsForRole('supervisor', 'attendance-log-review-needed', title, body, attendanceLogId, 'attendance_log');
         await createNotificationsForRole('admin', 'attendance-log-review-needed', `Admin: ${title}`, body, attendanceLogId, 'attendance_log');
+
+        const waMsg = `\ud83d\udd57 Attendance Check-Out\nEmployee: ${employeeName}\nProject: ${projectName}\nTime: ${checkOutFormattedTime}`;
+        await notifyRoleByWhatsApp('supervisor', waMsg, employeeId);
+        await notifyRoleByWhatsApp('admin', waMsg, employeeId);
 
         return {
             success: true,

--- a/src/app/actions/inventory-expense/logEmployeeExpense.ts
+++ b/src/app/actions/inventory-expense/logEmployeeExpense.ts
@@ -6,6 +6,7 @@ import { db } from '@/lib/firebase';
 import { collection, addDoc, serverTimestamp, doc, getDoc } from 'firebase/firestore';
 import type { EmployeeExpense } from '@/types/database';
 import { createNotificationsForRole, getUserDisplayName, getProjectName } from '@/app/actions/notificationsUtils';
+import { notifyRoleByWhatsApp } from '@/lib/notify';
 import { format } from 'date-fns';
 
 // Made LogExpenseSchema a local constant instead of exporting it.
@@ -74,6 +75,10 @@ export async function logEmployeeExpense(employeeId: string, data: LogExpenseInp
 
     await createNotificationsForRole('supervisor', 'expense-logged', title, body, docRef.id, 'expense');
     await createNotificationsForRole('admin', 'expense-logged', `Admin: ${title}`, body, docRef.id, 'expense');
+
+    const waMsg = `\ud83d\udcb0 Expense Logged\nEmployee: ${employeeName}\nProject: ${projectName}\nAmount: $${amount.toFixed(2)} (${type})`;
+    await notifyRoleByWhatsApp('supervisor', waMsg, employeeId);
+    await notifyRoleByWhatsApp('admin', waMsg, employeeId);
 
     return { success: true, message: 'Expense logged successfully and is pending approval.', expenseId: docRef.id };
   } catch (error) {

--- a/src/app/actions/leave/leaveActions.ts
+++ b/src/app/actions/leave/leaveActions.ts
@@ -18,6 +18,7 @@ import {
 } from 'firebase/firestore';
 import type { LeaveRequest, UserRole } from '@/types/database';
 import { createNotificationsForRole, getUserDisplayName, getProjectName } from '@/app/actions/notificationsUtils';
+import { notifyRoleByWhatsApp } from '@/lib/notify';
 import { format } from 'date-fns';
 
 
@@ -92,6 +93,10 @@ export async function requestLeave(employeeId: string, data: RequestLeaveInput):
 
     await createNotificationsForRole('supervisor', 'leave-requested', title, body, docRef.id, 'leave_request');
     await createNotificationsForRole('admin', 'leave-requested', `Admin: ${title}`, body, docRef.id, 'leave_request');
+
+    const waMsg = `\ud83d\udcdd Leave Request\nEmployee: ${employeeName}\nFrom: ${fromDateStr} To: ${toDateStr}${validatedProjectId ? `\nProject: ${projectName}` : ''}`;
+    await notifyRoleByWhatsApp('supervisor', waMsg, employeeId);
+    await notifyRoleByWhatsApp('admin', waMsg, employeeId);
 
     return { success: true, message: 'Leave request submitted.', requestId: docRef.id };
   } catch (error) {

--- a/src/app/actions/supervisor/assignTask.ts
+++ b/src/app/actions/supervisor/assignTask.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { db } from '@/lib/firebase';
 import { doc, updateDoc, arrayUnion, getDoc, serverTimestamp, Timestamp } from 'firebase/firestore';
 import { notifyUserByWhatsApp } from '@/lib/notify';
-import { getUserDisplayName, getProjectName } from '@/app/actions/notificationsUtils';
+import { getUserDisplayName, getProjectName, createSingleNotification } from '@/app/actions/notificationsUtils';
 import type { Task, TaskStatus } from '@/types/database';
 import { format } from 'date-fns';
 import { createQuickTaskForAssignment, CreateQuickTaskInput, CreateQuickTaskResult } from './createTask'; // Import createQuickTask
@@ -155,6 +155,14 @@ export async function assignTasksToEmployee(supervisorId: string, input: AssignT
         const taskNameStr = taskToProcess.taskName;
         const waMessage = `\ud83d\udccb Task Assigned\nProject: ${projectNameStr}\nTask: ${taskNameStr}${taskToProcess.isImportant ? ' (\u26a0\ufe0f Important)' : ''}\nDue: ${format(dueDate, "PP")}\nBy: ${supervisorName}\nNotes: ${supervisorNotes || 'None'}`;
         await notifyUserByWhatsApp(employeeId, waMessage);
+        await createSingleNotification(
+          employeeId,
+          'task-assigned',
+          `Task Assigned: ${taskNameStr}`,
+          `You have been assigned the task "${taskNameStr}" in project "${projectNameStr}" due ${format(dueDate, 'PP')}.`,
+          taskToProcess.taskId,
+          'task'
+        );
 
       } catch (taskError: any) {
         console.error(`Error assigning task ${taskToProcess.taskId}:`, taskError);

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -249,6 +249,7 @@ export interface LeaveRequest {
 }
 
 export type NotificationType =
+  | 'task-assigned'
   | 'task-started'
   | 'task-completed' // General completion, typically when status becomes 'completed' or 'verified'
   | 'task-needs-review' // Specifically when a task is submitted and AI or rules flag it for manual review


### PR DESCRIPTION
## Summary
- add `task-assigned` notification type
- implement `notifyRoleByWhatsApp`
- send WhatsApp alerts when leave is requested, expenses logged, or attendance logged
- notify employees in-app when tasks are assigned

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails to resolve modules)*

------
https://chatgpt.com/codex/tasks/task_e_6855c0c0e4a88320a68c207b068ee9ba