### PR TITLE
Switch plans to Firestore

### DIFF
--- a/src/app/actions/admin/billing/upgradePlan.ts
+++ b/src/app/actions/admin/billing/upgradePlan.ts
@@ -3,7 +3,7 @@
 
 import { db } from '@/lib/firebase';
 import { doc, updateDoc, getDoc, serverTimestamp } from 'firebase/firestore';
-import type { PlanDetails } from '@/lib/plans';
+import type { Plan } from '@/types/database';
 
 export interface UpgradePlanResult {
   success: boolean;
@@ -14,7 +14,7 @@ export interface UpgradePlanResult {
  * Simulates a plan upgrade after a successful payment.
  * In a real app, this would be triggered by a payment webhook.
  */
-export async function upgradeOrganizationPlan(adminId: string, organizationId: string, newPlan: PlanDetails): Promise<UpgradePlanResult> {
+export async function upgradeOrganizationPlan(adminId: string, organizationId: string, newPlan: Plan): Promise<UpgradePlanResult> {
     if (!adminId || !organizationId || !newPlan) {
         return { success: false, message: "Required information is missing." };
     }

--- a/src/app/actions/admin/getBillingInfo.ts
+++ b/src/app/actions/admin/getBillingInfo.ts
@@ -37,7 +37,7 @@ export async function getBillingInfo(adminId: string, organizationId: string): P
         }
 
         const orgData = orgDocSnap.data() as Organization;
-        const plan = getPlanById(orgData.planId);
+        const plan = await getPlanById(orgData.planId);
 
         return {
             success: true,

--- a/src/app/dashboard/admin/billing/page.tsx
+++ b/src/app/dashboard/admin/billing/page.tsx
@@ -13,7 +13,7 @@ import { useAuth } from '@/context/auth-context';
 import { getBillingInfo, type BillingInfo } from '@/app/actions/admin/getBillingInfo';
 import { checkTrialStatuses } from '@/app/actions/admin/billing/checkTrialStatuses';
 import { upgradeOrganizationPlan } from '@/app/actions/admin/billing/upgradePlan';
-import { getPlanById, plans } from '@/lib/plans';
+import { getPlanById, getPlans } from '@/lib/plans';
 import { RefreshCw, Users, Star, ExternalLink, ShieldCheck, Clock } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import Link from 'next/link';
@@ -72,7 +72,7 @@ export default function BillingPage() {
         toast({ title: "No Upgrade Path", description: "You are already on the highest plan." });
         return;
     }
-    const nextPlan = getPlanById(nextPlanId);
+    const nextPlan = await getPlanById(nextPlanId);
     if(!nextPlan) return;
 
     setIsUpgrading(true);

--- a/src/components/layout/app-sidebar-nav.tsx
+++ b/src/components/layout/app-sidebar-nav.tsx
@@ -146,7 +146,7 @@ function NavItemLink({ item, userPlanId, pathname, onLinkClick, roleSpecificDash
     async function checkPermission() {
       if (item.feature) {
         setIsCheckingPermission(true);
-        const allowed = isFeatureAllowed(userPlanId, item.feature);
+        const allowed = await isFeatureAllowed(userPlanId, item.feature);
         setIsAllowed(allowed);
         setIsCheckingPermission(false);
       } else {

--- a/src/components/registration/choose-plan-step.tsx
+++ b/src/components/registration/choose-plan-step.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -15,82 +15,33 @@ import { Progress } from "@/components/ui/progress";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { getPlans, type PlanDetails } from "@/lib/plans";
 
-export type PlanType = {
-  id: 'free' | 'pro' | 'business' | 'enterprise';
-  name: string;
-  priceMonthly: number;
-  priceYearly: number;
-  features: string[];
-  recommended?: boolean;
-  contactUs?: boolean;
-};
+export type PlanType = PlanDetails;
 
 interface ChoosePlanStepProps {
-  onDataChange: (data: { selectedPlan: PlanType | null, billingCycle: 'monthly' | 'yearly' }) => void;
+  onDataChange: (data: { selectedPlan: PlanType | null; billingCycle: 'monthly' | 'yearly' }) => void;
   selectedPlan: PlanType | null;
   billingCycle: 'monthly' | 'yearly' | null;
 }
-
-const plans: PlanType[] = [
-  {
-    id: "free",
-    name: "Free Trial",
-    priceMonthly: 0,
-    priceYearly: 0,
-    features: [
-      "Up to 5 Users",
-      "Basic Task Management",
-      "Standard Reporting",
-      "Email Support",
-    ],
-  },
-  {
-    id: "pro",
-    name: "Pro",
-    priceMonthly: 999,
-    priceYearly: 9999,
-    features: [
-      "Up to 50 Users",
-      "Advanced Task Management",
-      "Customizable Reports",
-      "Priority Support",
-      "Inventory, Invoicing & Payroll",
-    ],
-    recommended: true,
-  },
-  {
-    id: "business",
-    name: "Business",
-    priceMonthly: 2499,
-    priceYearly: 24999,
-    features: [
-      "Up to 200 Users",
-      "All Pro Features",
-      "Advanced Payroll",
-      "Dedicated Account Manager",
-    ],
-  },
-  {
-    id: "enterprise",
-    name: "Enterprise",
-    priceMonthly: 0,
-    priceYearly: 0,
-    features: [
-      "All Business Features",
-      "Custom Integrations",
-      "SLA & Uptime Guarantee",
-      "24/7 Premium Support",
-    ],
-    contactUs: true,
-  },
-];
 
 const ChoosePlanStep: React.FC<ChoosePlanStepProps> = ({
   onDataChange,
   selectedPlan,
   billingCycle,
 }) => {
+  const [plans, setPlans] = useState<PlanType[]>([])
+  const [loadingPlans, setLoadingPlans] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      const fetched = await getPlans()
+      setPlans(fetched)
+      setLoadingPlans(false)
+    }
+    load()
+  }, [])
+
   const currentBillingCycle = billingCycle || 'monthly';
 
   const handlePlanSelection = (plan: PlanType) => {
@@ -129,7 +80,9 @@ const ChoosePlanStep: React.FC<ChoosePlanStepProps> = ({
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          {plans.map((plan) => (
+          {loadingPlans ? (
+            <p className="col-span-4 text-center">Loading plans...</p>
+          ) : plans.map((plan) => (
             <Card
               key={plan.name}
               onClick={() => handlePlanSelection(plan)}

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -2,63 +2,87 @@
 
 // A simple type definition for a plan's features and limits.
 // In a real app, this might be more complex.
-export interface PlanDetails {
-  id: 'free' | 'pro' | 'business' | 'enterprise';
-  name: string;
-  priceMonthly: number;
-  priceYearly: number;
-  userLimit: number;
-  features: ('Tasks' | 'Attendance' | 'Expenses' | 'Payroll' | 'Invoicing' | 'Advanced Reporting' | 'Priority Support')[];
-  recommended?: boolean;
-  contactUs?: boolean;
-}
+import { db } from '@/lib/firebase'
+import { collection, getDocs, type QueryDocumentSnapshot } from 'firebase/firestore'
+import type { Plan, PlanFeature } from '@/types/database'
 
-// Single source of truth for all plan information.
-export const plans: Record<string, PlanDetails> = {
-  free: {
+export type PlanDetails = Plan
+
+let plansCache: PlanDetails[] | null = null
+let cacheTimestamp: number | null = null
+const CACHE_DURATION_MS = 5 * 60 * 1000
+
+const defaultPlans: PlanDetails[] = [
+  {
     id: 'free',
-    name: "Free Trial",
+    name: 'Free Trial',
     priceMonthly: 0,
     priceYearly: 0,
     userLimit: 5,
-    features: ["Tasks", "Attendance", "Expenses"],
+    features: ['Tasks', 'Attendance', 'Expenses'],
   },
-  pro: {
+  {
     id: 'pro',
-    name: "Pro",
+    name: 'Pro',
     priceMonthly: 999,
     priceYearly: 9999,
     userLimit: 50,
-    features: ["Tasks", "Attendance", "Expenses", "Payroll", "Invoicing"],
+    features: ['Tasks', 'Attendance', 'Expenses', 'Payroll', 'Invoicing'],
     recommended: true,
   },
-  business: {
+  {
     id: 'business',
-    name: "Business",
+    name: 'Business',
     priceMonthly: 2499,
     priceYearly: 24999,
     userLimit: 200,
-    features: ["Tasks", "Attendance", "Expenses", "Payroll", "Invoicing", "Advanced Reporting", "Priority Support"],
+    features: ['Tasks', 'Attendance', 'Expenses', 'Payroll', 'Invoicing', 'Advanced Reporting', 'Priority Support'],
   },
-  enterprise: {
+  {
     id: 'enterprise',
-    name: "Enterprise",
+    name: 'Enterprise',
     priceMonthly: 0,
     priceYearly: 0,
-    userLimit: Infinity, // Or a very high number
-    features: ["Tasks", "Attendance", "Expenses", "Payroll", "Invoicing", "Advanced Reporting", "Priority Support"],
+    userLimit: Infinity,
+    features: ['Tasks', 'Attendance', 'Expenses', 'Payroll', 'Invoicing', 'Advanced Reporting', 'Priority Support'],
     contactUs: true,
   },
-};
+]
+
+export async function getPlans(): Promise<PlanDetails[]> {
+  const now = Date.now()
+  if (plansCache && cacheTimestamp && now - cacheTimestamp < CACHE_DURATION_MS) {
+    return plansCache
+  }
+  try {
+    const snap = await getDocs(collection(db, 'plans'))
+    if (snap.empty) {
+      plansCache = defaultPlans
+      cacheTimestamp = now
+      return defaultPlans
+    }
+    const plans = snap.docs.map((d: QueryDocumentSnapshot) => ({ id: d.id, ...d.data() } as PlanDetails))
+    plansCache = plans
+    cacheTimestamp = now
+    return plans
+  } catch (err) {
+    console.error('Error fetching plans:', err)
+    return defaultPlans
+  }
+}
+
+// Single source of truth for all plan information.
+// Deprecated static plan map left for reference only.
 
 /**
  * Retrieves the details for a given plan ID.
  * @param planId The ID of the plan.
  * @returns The plan details, or undefined if not found.
  */
-export function getPlanById(planId?: string): PlanDetails | undefined {
-  if (!planId) return undefined;
-  return Object.values(plans).find(p => p.id === planId);
+export async function getPlanById(planId?: string): Promise<PlanDetails | undefined> {
+  if (!planId) return undefined
+  const plans = await getPlans()
+  return plans.find(p => p.id === planId)
 }
 
 /**
@@ -67,8 +91,8 @@ export function getPlanById(planId?: string): PlanDetails | undefined {
  * @param feature The feature to check for.
  * @returns True if the feature is allowed, false otherwise.
  */
-export function isFeatureAllowed(planId: string | undefined, feature: PlanDetails['features'][number]): boolean {
-  const plan = getPlanById(planId);
-  if (!plan) return false; // Default to not allowed if plan is unknown
-  return plan.features.includes(feature);
+export async function isFeatureAllowed(planId: string | undefined, feature: PlanFeature): Promise<boolean> {
+  const plan = await getPlanById(planId)
+  if (!plan) return false
+  return plan.features.includes(feature)
 }


### PR DESCRIPTION
## Summary
- pull subscription plan info from Firestore
- load plan list dynamically in registration flow
- handle feature permissions asynchronously across billing and payroll pages

## Testing
- `npm run typecheck` *(fails: Cannot find modules)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6d25b53883208bd7d76d11e3350d