### PR TITLE
Add illustration assets and component

### DIFF
--- a/public/illustrations/admin_dashboard.svg
+++ b/public/illustrations/admin_dashboard.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <rect width="100" height="70" x="10" y="40" fill="#e2e8f0" stroke="#94a3b8" stroke-width="2"/>
+  <rect width="15" height="20" x="25" y="70" fill="#60a5fa"/>
+  <rect width="15" height="30" x="45" y="60" fill="#3b82f6"/>
+  <rect width="15" height="40" x="65" y="50" fill="#1d4ed8"/>
+  <rect width="15" height="25" x="85" y="65" fill="#93c5fd"/>
+</svg>

--- a/public/illustrations/attendance_status.svg
+++ b/public/illustrations/attendance_status.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <rect width="100" height="80" x="10" y="20" fill="#e2e8f0" stroke="#94a3b8" stroke-width="2"/>
+  <rect width="80" height="10" x="20" y="35" fill="#cbd5e1"/>
+  <rect width="50" height="10" x="20" y="50" fill="#60a5fa"/>
+  <rect width="50" height="10" x="20" y="65" fill="#1d4ed8"/>
+</svg>

--- a/public/illustrations/expense_submission.svg
+++ b/public/illustrations/expense_submission.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <rect width="80" height="100" x="20" y="10" fill="#e2e8f0" stroke="#94a3b8" stroke-width="2"/>
+  <rect width="50" height="25" x="35" y="70" fill="#60a5fa"/>
+  <line x1="35" y1="45" x2="85" y2="45" stroke="#1d4ed8" stroke-width="4"/>
+  <line x1="35" y1="55" x2="85" y2="55" stroke="#3b82f6" stroke-width="4"/>
+</svg>

--- a/public/illustrations/illustrations.json
+++ b/public/illustrations/illustrations.json
@@ -1,0 +1,9 @@
+{
+  "adminDashboard": "/illustrations/admin_dashboard.svg",
+  "punchInOut": "/illustrations/punch_in_out.svg",
+  "taskManagement": "/illustrations/task_management.svg",
+  "expenseSubmission": "/illustrations/expense_submission.svg",
+  "payroll": "/illustrations/payroll.svg",
+  "attendanceStatus": "/illustrations/attendance_status.svg",
+  "whatsappNotifications": "/illustrations/whatsapp_notifications.svg"
+}

--- a/public/illustrations/payroll.svg
+++ b/public/illustrations/payroll.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <rect width="100" height="60" x="10" y="30" fill="#e2e8f0" stroke="#94a3b8" stroke-width="2"/>
+  <circle cx="40" cy="60" r="15" fill="#60a5fa"/>
+  <text x="65" y="67" font-size="20" fill="#1d4ed8" font-family="sans-serif">$</text>
+</svg>

--- a/public/illustrations/punch_in_out.svg
+++ b/public/illustrations/punch_in_out.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <circle cx="60" cy="60" r="45" fill="#e2e8f0" stroke="#94a3b8" stroke-width="2"/>
+  <path d="M60 30v30l20 10" stroke="#1d4ed8" stroke-width="4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/public/illustrations/task_management.svg
+++ b/public/illustrations/task_management.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <rect width="80" height="100" x="20" y="10" fill="#e2e8f0" stroke="#94a3b8" stroke-width="2"/>
+  <line x1="35" y1="35" x2="85" y2="35" stroke="#1d4ed8" stroke-width="4"/>
+  <line x1="35" y1="55" x2="85" y2="55" stroke="#3b82f6" stroke-width="4"/>
+  <line x1="35" y1="75" x2="85" y2="75" stroke="#60a5fa" stroke-width="4"/>
+</svg>

--- a/public/illustrations/whatsapp_notifications.svg
+++ b/public/illustrations/whatsapp_notifications.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <circle cx="60" cy="60" r="45" fill="#4ade80" stroke="#166534" stroke-width="2"/>
+  <path d="M40 70l5-15 15 10 15-10 5 15-20 10z" fill="#ecfdf5"/>
+</svg>

--- a/src/app/dashboard/admin/overview/page.tsx
+++ b/src/app/dashboard/admin/overview/page.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { PageHeader } from "@/components/shared/page-header";
+import Illustration from "@/components/ui/illustration";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
@@ -165,6 +166,7 @@ export default function AdminOverviewPage() {
           </Button>
         }
       />
+      <Illustration name="adminDashboard" alt="Admin dashboard analytics" className="mx-auto mb-4 w-full max-w-md" />
 
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-5">
         {stats ? (

--- a/src/app/dashboard/employee/attendance/page.tsx
+++ b/src/app/dashboard/employee/attendance/page.tsx
@@ -16,6 +16,7 @@ import { fetchAllProjects, ProjectForSelection } from '@/app/actions/common/fetc
 import { format, parseISO, isValid, differenceInSeconds, addMonths, subMonths, startOfMonth, endOfMonth, eachDayOfInterval, getDay, isSameDay, isToday, isPast } from 'date-fns';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
+import Illustration from '@/components/ui/illustration';
 
 interface StatCardProps {
     label: string;
@@ -210,6 +211,7 @@ export default function EmployeeAttendanceCalendarPage() {
           </Button>
         }
       />
+      <Illustration name="punchInOut" alt="Time clock" className="mx-auto mb-4 w-full max-w-md" />
       <Card>
         <CardHeader>
             <div className="flex justify-between items-center">

--- a/src/components/ui/illustration.tsx
+++ b/src/components/ui/illustration.tsx
@@ -1,0 +1,14 @@
+import Image from "next/image";
+import illustrations, { IllustrationKey } from "@/lib/illustrations";
+
+interface IllustrationProps {
+  name: IllustrationKey;
+  className?: string;
+  alt?: string;
+}
+
+export default function Illustration({ name, className, alt }: IllustrationProps) {
+  const src = illustrations[name];
+  if (!src) return null;
+  return <Image src={src} alt={alt || name} width={300} height={200} className={className} />;
+}

--- a/src/lib/illustrations.ts
+++ b/src/lib/illustrations.ts
@@ -1,0 +1,12 @@
+const illustrations = {
+  adminDashboard: '/illustrations/admin_dashboard.svg',
+  punchInOut: '/illustrations/punch_in_out.svg',
+  taskManagement: '/illustrations/task_management.svg',
+  expenseSubmission: '/illustrations/expense_submission.svg',
+  payroll: '/illustrations/payroll.svg',
+  attendanceStatus: '/illustrations/attendance_status.svg',
+  whatsappNotifications: '/illustrations/whatsapp_notifications.svg'
+} as const;
+
+export type IllustrationKey = keyof typeof illustrations;
+export default illustrations;


### PR DESCRIPTION
## Summary
- add simple illustration SVGs and JSON mapping
- create Illustration component
- display illustrations on admin overview and employee attendance pages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686f5e1b55848320a5c38bb10e03bbeb