### PR TITLE
Improve notification priority

### DIFF
--- a/src/actions/admin/assignTask.ts
+++ b/src/actions/admin/assignTask.ts
@@ -161,7 +161,9 @@ export async function assignTasksToEmployee(supervisorId: string, input: AssignT
           `Task Assigned: ${taskNameStr}`,
           `You have been assigned the task "${taskNameStr}" in project "${projectNameStr}" due ${format(dueDate, 'PP')}.`,
           taskToProcess.taskId,
-          'task'
+          'task',
+          'task',
+          taskToProcess.isImportant ? 'high' : 'normal'
         );
 
       } catch (taskError: any) {

--- a/src/app/actions/admin/assignTask.ts
+++ b/src/app/actions/admin/assignTask.ts
@@ -160,12 +160,13 @@ export async function assignTasksToEmployee(supervisorId: string, input: AssignT
         await notifyUserByWhatsApp(employeeId, organizationId, waMessage);
         await createSingleNotification(
           employeeId,
-          organizationId,
           'task-assigned',
           `Task Assigned: ${taskNameStr}`,
           `You have been assigned the task "${taskNameStr}" in project "${projectNameStr}" due ${format(dueDate, 'PP')}.`,
           taskToProcess.taskId,
-          'task'
+          'task',
+          'task',
+          taskToProcess.isImportant ? 'high' : 'normal'
         );
 
       } catch (taskError: any) {

--- a/src/app/actions/attendance.ts
+++ b/src/app/actions/attendance.ts
@@ -182,8 +182,28 @@ export async function logAttendance(
         const title = `Attendance: ${employeeName} Checked In`;
         const body = `${employeeName} checked in for project "${projectName}" at ${checkInFormattedTime}. Review may be needed.`;
 
-        await createNotificationsForRole('supervisor', 'attendance-log-review-needed', title, body, docRef.id, 'attendance_log');
-        await createNotificationsForRole('admin', 'attendance-log-review-needed', `Admin: ${title}`, body, docRef.id, 'attendance_log');
+        await createNotificationsForRole(
+          'supervisor',
+          'attendance-log-review-needed',
+          title,
+          body,
+          docRef.id,
+          'attendance_log',
+          undefined,
+          'attendance',
+          'normal'
+        );
+        await createNotificationsForRole(
+          'admin',
+          'attendance-log-review-needed',
+          `Admin: ${title}`,
+          body,
+          docRef.id,
+          'attendance_log',
+          undefined,
+          'attendance',
+          'normal'
+        );
 
         const waMsg = `\u23f0 Attendance Check-In\nEmployee: ${employeeName}\nProject: ${projectName}\nTime: ${checkInFormattedTime}`;
         await notifyRoleByWhatsApp('supervisor', waMsg, employeeId);
@@ -337,8 +357,28 @@ export async function checkoutAttendance(
         }
         body += ` This log may require review.`;
 
-        await createNotificationsForRole('supervisor', 'attendance-log-review-needed', title, body, attendanceLogId, 'attendance_log');
-        await createNotificationsForRole('admin', 'attendance-log-review-needed', `Admin: ${title}`, body, attendanceLogId, 'attendance_log');
+        await createNotificationsForRole(
+          'supervisor',
+          'attendance-log-review-needed',
+          title,
+          body,
+          attendanceLogId,
+          'attendance_log',
+          undefined,
+          'attendance',
+          'normal'
+        );
+        await createNotificationsForRole(
+          'admin',
+          'attendance-log-review-needed',
+          `Admin: ${title}`,
+          body,
+          attendanceLogId,
+          'attendance_log',
+          undefined,
+          'attendance',
+          'normal'
+        );
 
         const waMsg = `\ud83d\udd57 Attendance Check-Out\nEmployee: ${employeeName}\nProject: ${projectName}\nTime: ${checkOutFormattedTime}`;
         await notifyRoleByWhatsApp('supervisor', waMsg, employeeId);

--- a/src/app/actions/employee/updateTask.ts
+++ b/src/app/actions/employee/updateTask.ts
@@ -106,7 +106,9 @@ export async function startEmployeeTask(input: StartTaskInput): Promise<StartTas
         `Task Started: ${rawTaskData.taskName}`,
         `${employeeName} started task "${rawTaskData.taskName}" for project "${projectName}".`,
         taskId,
-        'task'
+        'task',
+        'task',
+        'normal'
       );
       const waMsg = `\u2705 Task Updated\nTask: ${rawTaskData.taskName}\nStatus: in-progress\nBy: ${employeeName}`;
       await notifyUserByWhatsApp(supervisorId, waMsg);
@@ -117,7 +119,10 @@ export async function startEmployeeTask(input: StartTaskInput): Promise<StartTas
       `Admin: Task Started - ${rawTaskData.taskName}`,
       `${employeeName} started task "${rawTaskData.taskName}" for project "${projectName}". Assigned by ${supervisorId}.`,
       taskId,
-      'task'
+      'task',
+      undefined,
+      'task',
+      'normal'
     );
 
     const optimisticUpdateData: Partial<Task> = {
@@ -319,18 +324,23 @@ export async function completeEmployeeTask(input: CompleteTaskInput): Promise<Co
         supervisorNotificationTitle,
         supervisorNotificationBody,
         taskId,
-        'task'
+        'task',
+        'task',
+        'normal'
       );
       const waMsg = `\u2705 Task Updated\nTask: ${rawTaskData.taskName}\nStatus: ${finalStatus}\nBy: ${employeeName}`;
       await notifyUserByWhatsApp(supervisorId, waMsg);
     }
     await createNotificationsForRole(
       'admin',
-      supervisorNotificationType, 
+      supervisorNotificationType,
       `Admin: ${supervisorNotificationTitle}`,
       supervisorNotificationBody + ` Assigned by ${supervisorId}.`,
       taskId,
-      'task'
+      'task',
+      undefined,
+      'task',
+      'normal'
     );
 
     return { success: true, message: `Task marked as ${finalStatus}.`, finalStatus };

--- a/src/app/actions/inventory-expense/logEmployeeExpense.ts
+++ b/src/app/actions/inventory-expense/logEmployeeExpense.ts
@@ -74,8 +74,28 @@ export async function logEmployeeExpense(employeeId: string, data: LogExpenseInp
     const title = `New Expense: ${employeeName}`;
     const body = `${employeeName} logged a new expense of $${amount.toFixed(2)} for project "${projectName}" (${type}) on ${expenseDate}. It requires review.`;
 
-    await createNotificationsForRole('supervisor', 'expense-logged', title, body, docRef.id, 'expense');
-    await createNotificationsForRole('admin', 'expense-logged', `Admin: ${title}`, body, docRef.id, 'expense');
+    await createNotificationsForRole(
+      'supervisor',
+      'expense-logged',
+      title,
+      body,
+      docRef.id,
+      'expense',
+      undefined,
+      'expense',
+      'normal'
+    );
+    await createNotificationsForRole(
+      'admin',
+      'expense-logged',
+      `Admin: ${title}`,
+      body,
+      docRef.id,
+      'expense',
+      undefined,
+      'expense',
+      'normal'
+    );
 
     const waMsg = `\ud83d\udcb0 Expense Logged\nEmployee: ${employeeName}\nProject: ${projectName}\nAmount: $${amount.toFixed(2)} (${type})`;
     await notifyRoleByWhatsApp('supervisor', waMsg, employeeId);

--- a/src/app/actions/leave/leaveActions.ts
+++ b/src/app/actions/leave/leaveActions.ts
@@ -92,8 +92,28 @@ export async function requestLeave(employeeId: string, data: RequestLeaveInput):
     const title = `Leave Request: ${employeeName}`;
     const body = `${employeeName} requested ${leaveType} leave from ${fromDateStr} to ${toDateStr} ${validatedProjectId ? `for project "${projectName}"` : ''}. Reason: ${reason.substring(0, 100)}${reason.length > 100 ? '...' : ''}`;
 
-    await createNotificationsForRole('supervisor', 'leave-requested', title, body, docRef.id, 'leave_request');
-    await createNotificationsForRole('admin', 'leave-requested', `Admin: ${title}`, body, docRef.id, 'leave_request');
+    await createNotificationsForRole(
+      'supervisor',
+      'leave-requested',
+      title,
+      body,
+      docRef.id,
+      'leave_request',
+      undefined,
+      'attendance',
+      'normal'
+    );
+    await createNotificationsForRole(
+      'admin',
+      'leave-requested',
+      `Admin: ${title}`,
+      body,
+      docRef.id,
+      'leave_request',
+      undefined,
+      'attendance',
+      'normal'
+    );
 
     const waMsg = `\ud83d\udcdd Leave Request\nEmployee: ${employeeName}\nFrom: ${fromDateStr} To: ${toDateStr}${validatedProjectId ? `\nProject: ${projectName}` : ''}`;
     await notifyRoleByWhatsApp('supervisor', waMsg, employeeId);
@@ -136,7 +156,17 @@ export async function reviewLeaveRequest(reviewerId: string, requestId: string, 
     const reviewerName = await getUserDisplayName(reviewerId);
     const title = `Leave ${action === 'approve' ? 'Approved' : 'Rejected'}: ${employeeName}`;
     const body = `Leave request for ${employeeName} was ${status} by ${reviewerName}.`;
-    await createNotificationsForRole('admin', action === 'approve' ? 'leave-approved-by-supervisor' : 'leave-rejected-by-supervisor', title, body, requestId, 'leave_request', reviewerId);
+    await createNotificationsForRole(
+      'admin',
+      action === 'approve' ? 'leave-approved-by-supervisor' : 'leave-rejected-by-supervisor',
+      title,
+      body,
+      requestId,
+      'leave_request',
+      reviewerId,
+      'attendance',
+      action === 'approve' ? 'normal' : 'high'
+    );
 
 
     return { success: true, message: `Leave request ${status}.` };

--- a/src/app/actions/notificationsUtils.ts
+++ b/src/app/actions/notificationsUtils.ts
@@ -3,7 +3,16 @@
 
 import { db } from '@/lib/firebase';
 import { collection, addDoc, serverTimestamp, doc, getDoc, query, where, getDocs, writeBatch } from 'firebase/firestore';
-import type { Notification, NotificationType, RelatedItemType, UserRole, Employee, Project } from '@/types/database';
+import type {
+  Notification,
+  NotificationType,
+  RelatedItemType,
+  UserRole,
+  Employee,
+  Project,
+  NotificationPriority,
+  NotificationCategory,
+} from '@/types/database';
 
 /**
  * Fetches the display name for a user.
@@ -51,7 +60,9 @@ export async function createSingleNotification(
   title: string,
   body: string,
   relatedItemId?: string,
-  relatedItemType?: RelatedItemType
+  relatedItemType?: RelatedItemType,
+  category: NotificationCategory = 'general',
+  priority: NotificationPriority = 'normal'
 ): Promise<void> {
   if (!targetUserId) {
     console.warn('createSingleNotification: targetUserId is missing. Notification not created.');
@@ -65,6 +76,8 @@ export async function createSingleNotification(
       body,
       relatedItemId: relatedItemId || '',
       relatedItemType: relatedItemType || 'none',
+      category,
+      priority,
       read: false,
       createdAt: serverTimestamp(),
     };
@@ -85,7 +98,9 @@ export async function createNotificationsForRole(
   body: string,
   relatedItemId?: string,
   relatedItemType?: RelatedItemType,
-  excludeUserId?: string
+  excludeUserId?: string,
+  category: NotificationCategory = 'general',
+  priority: NotificationPriority = 'normal'
 ): Promise<void> {
   try {
     const usersCollectionRef = collection(db, 'users');
@@ -96,7 +111,16 @@ export async function createNotificationsForRole(
     querySnapshot.forEach((userDoc) => {
       if (userDoc.id !== excludeUserId) {
         notificationPromises.push(
-          createSingleNotification(userDoc.id, type, title, body, relatedItemId, relatedItemType)
+          createSingleNotification(
+            userDoc.id,
+            type,
+            title,
+            body,
+            relatedItemId,
+            relatedItemType,
+            category,
+            priority
+          )
         );
       }
     });

--- a/src/app/actions/supervisor/reviewExpenseActions.ts
+++ b/src/app/actions/supervisor/reviewExpenseActions.ts
@@ -63,7 +63,17 @@ export async function approveEmployeeExpense(input: ApproveExpenseInput): Promis
     const supervisorName = await getUserDisplayName(supervisorId);
     const title = `Admin: Expense Approved - ${employeeName}`;
     const body = `Expense of $${expenseData.amount.toFixed(2)} for ${employeeName} (Project: ${projectName}) was approved by Supervisor ${supervisorName}.`;
-    await createNotificationsForRole('admin', 'expense-approved-by-supervisor', title, body, expenseId, 'expense', supervisorId);
+    await createNotificationsForRole(
+      'admin',
+      'expense-approved-by-supervisor',
+      title,
+      body,
+      expenseId,
+      'expense',
+      supervisorId,
+      'expense',
+      'normal'
+    );
 
     return { success: true, message: "Expense approved successfully." };
   } catch (error) {
@@ -124,7 +134,17 @@ export async function rejectEmployeeExpense(input: RejectExpenseInput): Promise<
     const supervisorName = await getUserDisplayName(supervisorId);
     const title = `Admin: Expense Rejected - ${employeeName}`;
     const body = `Expense of $${expenseData.amount.toFixed(2)} for ${employeeName} (Project: ${projectName}) was rejected by Supervisor ${supervisorName}. Reason: ${rejectionReason}`;
-    await createNotificationsForRole('admin', 'expense-rejected-by-supervisor', title, body, expenseId, 'expense', supervisorId);
+    await createNotificationsForRole(
+      'admin',
+      'expense-rejected-by-supervisor',
+      title,
+      body,
+      expenseId,
+      'expense',
+      supervisorId,
+      'expense',
+      'high'
+    );
 
     return { success: true, message: "Expense rejected successfully." };
   } catch (error) {

--- a/src/app/actions/supervisor/reviewTask.ts
+++ b/src/app/actions/supervisor/reviewTask.ts
@@ -65,7 +65,9 @@ export async function approveTaskBySupervisor(input: ApproveTaskInput): Promise<
       `Task "${taskName}" for employee ${employeeName} (Project: ${projectName}) was approved by Supervisor ${supervisorName}.`,
       taskId,
       'task',
-      supervisorId // Exclude the supervisor themselves if they are also an admin
+      supervisorId, // Exclude the supervisor themselves if they are also an admin
+      'task',
+      'normal'
     );
 
     return { success: true, message: 'Task approved successfully and status set to verified.', updatedStatus: 'verified' };
@@ -126,7 +128,9 @@ export async function rejectTaskBySupervisor(input: RejectTaskInput): Promise<Re
       `Task "${taskName}" for employee ${employeeName} (Project: ${projectName}) was rejected by Supervisor ${supervisorName}. Reason: ${rejectionReason}`,
       taskId,
       'task',
-      supervisorId // Exclude the supervisor themselves if they are also an admin
+      supervisorId, // Exclude the supervisor themselves if they are also an admin
+      'task',
+      'high'
     );
 
     return { success: true, message: 'Task rejected successfully.', updatedStatus: 'rejected' };

--- a/src/components/layout/notification-bell.tsx
+++ b/src/components/layout/notification-bell.tsx
@@ -39,15 +39,17 @@ export function NotificationBell() {
 
     const unsub = onSnapshot(q, (snap) => {
       const data = snap.docs.map((d) => {
-          const docData = d.data();
-          const createdAtDate = docData.createdAt instanceof Timestamp 
-                                ? docData.createdAt.toDate() 
-                                : new Date(); 
-          return { 
-              id: d.id, 
-              ...(docData as Omit<Notification, 'id' | 'createdAt'>),
-              createdAt: createdAtDate as any 
-          };
+        const docData = d.data();
+        const createdAtDate = docData.createdAt instanceof Timestamp
+          ? docData.createdAt.toDate()
+          : new Date();
+        return {
+          id: d.id,
+          ...(docData as Omit<Notification, 'id' | 'createdAt'>),
+          category: docData.category || 'general',
+          priority: docData.priority || 'normal',
+          createdAt: createdAtDate as any,
+        };
       });
       setNotifications(data as Notification[]);
     });
@@ -116,13 +118,25 @@ export function NotificationBell() {
     const itemLink = getRelatedItemLink(notification);
     
     const content = (
-      <div 
-        key={notification.id} 
+      <div
+        key={notification.id}
         className={`p-3 rounded-lg border ${notification.read ? 'bg-muted/50 opacity-70' : 'bg-background shadow-sm'}`}
       >
         <div className="flex justify-between items-start">
-          <p className="font-medium text-sm pr-2">{notification.title}</p>
-          {!notification.read && <Badge variant="destructive" className="text-xs px-1.5 py-0.5">New</Badge>}
+          <div className="flex items-center gap-2 pr-2">
+            <p className="font-medium text-sm">{notification.title}</p>
+            {notification.priority !== 'normal' && (
+              <Badge
+                variant={notification.priority === 'critical' ? 'destructive' : 'secondary'}
+                className="text-[10px] px-1.5 py-0.5 capitalize"
+              >
+                {notification.priority}
+              </Badge>
+            )}
+          </div>
+          {!notification.read && (
+            <Badge variant="destructive" className="text-xs px-1.5 py-0.5">New</Badge>
+          )}
         </div>
         <p className="text-xs text-muted-foreground mt-0.5">{notification.body}</p>
         <div className="flex justify-between items-center mt-2">

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -48,7 +48,7 @@ const Toast = React.forwardRef<
     VariantProps<typeof toastVariants> & {
       duration?: number;
     }
->(({ className, variant, duration = 4000, ...props }, ref) => {
+>(({ className, variant, duration = 5000, ...props }, ref) => {
   const [isPaused, setIsPaused] = React.useState(false);
 
   return (

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -311,6 +311,15 @@ export type RelatedItemType =
   | 'project'
   | 'none';
 
+export type NotificationPriority = 'normal' | 'high' | 'critical';
+export type NotificationCategory =
+  | 'task'
+  | 'attendance'
+  | 'expense'
+  | 'payroll'
+  | 'admin'
+  | 'general';
+
 /**
  * Represents an in-app notification for a user.
  * Stored in 'notifications' collection.
@@ -323,6 +332,8 @@ export interface Notification {
   body: string;
   relatedItemId?: string; // ID of the task, expense, leave request, etc.
   relatedItemType?: RelatedItemType; // To help UI know what 'relatedItemId' refers to
+  category: NotificationCategory;
+  priority: NotificationPriority;
   read: boolean;
   createdAt: Timestamp;
 }


### PR DESCRIPTION
## Summary
- extend Firestore notification schema with `priority` and `category`
- allow `createSingleNotification` and `createNotificationsForRole` to set priority
- show priority badges in the notification bell
- fix assign task notification order and priority
- increase toast default duration
- pass notification category/priority through all action helpers

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing type definitions)*


------
https://chatgpt.com/codex/tasks/task_e_686f628f13c88320a812f6d1cf85ad87